### PR TITLE
GHC 8 compatibility, and compatibility with newer build-depends

### DIFF
--- a/QuasiText.cabal
+++ b/QuasiText.cabal
@@ -16,5 +16,5 @@ cabal-version:       >=1.8
 
 library
   exposed-modules:     Text.QuasiText
-  build-depends:       base >= 4.5.0.0 && < 5.0.0.0, template-haskell, haskell-src-meta, attoparsec, text
+  build-depends:       base >= 4.5.0.0 && < 5.0.0.0, template-haskell, haskell-src-meta, attoparsec, text, th-lift-instances
   hs-source-dirs:      src

--- a/src/Text/QuasiText.hs
+++ b/src/Text/QuasiText.hs
@@ -3,6 +3,7 @@
 -- A simple 'QuasiQuoter' for 'Text' strings. Note that to use 'embed' you need to use the OverloadedStrings extension.
 
 module Text.QuasiText (embed, Chunk (..), getChunks) where
+import Instances.TH.Lift () -- for the `instance Lift Text`
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH
@@ -15,9 +16,6 @@ import Data.Char
 
 import Data.Monoid
 import Control.Applicative
-                        
-instance Lift Text where
-    lift = litE . stringL . T.unpack
 
 data Chunk 
     = T Text -- ^ text
@@ -57,7 +55,7 @@ embed = QuasiQuoter
                             Left  e -> error e
                             Right e -> appE [| toText |] (return e)
 
-                        V t -> appE [| toText |] (global (mkName (T.unpack t)))
+                        V t -> appE [| toText |] (varE (mkName (T.unpack t)))
 
         in appE [| T.concat |] (listE chunks)
     }


### PR DESCRIPTION
Fixes #3.

The `instance Lift Text` is already implicitly imported,
because `haskell-src-meta` imports from `th-orphans`, which
imports from `th-lift-instances` which has this instance.

In order to resolve the duplicate instance, this commit
adds `th-lift-instances` directly to the `build-depends`,
making the dependency explicit.

The `global` TH function is deprecated, and according to the
corresponding deprecation warning, `varE` should be used;
according to what I've found, it exists in all versions of
template-haskell.
